### PR TITLE
Option to skip empty roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ the ordering of rows and columns, essentially transposing the statement.
 \usepackage[horizontal]{credits}
 ```
 
+Moreover, if some of the roles are empty (i.e., no contributor) and you want
+to hide them, pass the `skipempty` key:
+
+```latex
+\usepackage[skipempty]{credits}
+```
+
+
 If you are only interested in the textual statement, you can use the
 `separator` package option to slightly adjust its formatting.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If you are only interested in the textual statement, you can use the
 
 % This would create a list of contributions. Personally, I do not like
 % this format too much.
-\usepackage[separator = {\newline}]credits}
+\usepackage[separator = {\newline}]{credits}
 ```
 
 Use `\insertcreditsstatement` to place your textual statement anywhere.

--- a/credits.sty
+++ b/credits.sty
@@ -166,10 +166,12 @@
 % Required to ensure that we can count active concepts later on when
 % generating text statements.
 \newcounter{CREDITS@concepts}
+\newcounter{CREDITSADDED@concepts}
 
 \newcommand{\insertcreditsstatement}{%
-  \foreach \concept [count = \i] in \concepts {% 
+  \foreach \concept [count = \i] in \concepts {%
     \setcounter{CREDITS@concepts}{0}%
+    \setcounter{CREDITSADDED@concepts}{0}%
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
@@ -185,21 +187,27 @@
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
-          \pgfmathparse{\entry > 0 ? "\name" : ""}
-          \pgfmathresult%
-          \ifthenelse{\equal{\pgfmathresult}{}}{%
-          }{%
-            \ifnum\value{CREDITS@concepts} > 1%
-              \pgfmathparse{\value{CREDITS@concepts} - \n > 0 ? 1 : 0}%
-              \ifnum\pgfmathresult = 1
-                ,
-               \fi%
-            \fi%
-          }%
+          % Check if the author contributed to the concept
+          % If so, add a comma before the author acronym
+          % Then add the author acronym
+          \pgfmathparse{\entry > 0 ? ", " : ""}%
+          % Add comma if there are >1 authors AND at least one author was already added
+          \ifnum\value{CREDITS@concepts} > 1
+            \ifnum\value{CREDITSADDED@concepts} > 0
+                \pgfmathresult
+            \fi
+          \fi
+          % Add the author acronym if they contributed to the concept
+          \pgfmathparse{\entry > 0 ? "\name" : ""}%
+          \pgfmathresult
+          \ifnum\entry > 0
+            \addtocounter{CREDITSADDED@concepts}{1}%
+        \fi
         }%
         {}%
       }%
     }%
+    % Only add a separator if this is not the last concept
     \ifthenelse{\i < 14}{%
       \CREDITS@separator{}
     }%

--- a/credits.sty
+++ b/credits.sty
@@ -175,7 +175,7 @@
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
-          \pgfmathparse{\entry > 0 ? 1 : 0}%
+          \pgfmathparse{int(\entry > 0 ? 1 : 0)}%
           \ifthenelse{\pgfmathresult > 0}{%
             \addtocounter{CREDITS@concepts}{1}%
           }{}%
@@ -184,25 +184,20 @@
       }%
     }%
     {\bfseries\concept: }%
+    % Initialize a counter for the number of authors for this concept
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
           % Check if the author contributed to the concept
-          % If so, add a comma before the author acronym
-          % Then add the author acronym
-          \pgfmathparse{\entry > 0 ? ", " : ""}%
-          % Add comma if there are >1 authors AND at least one author was already added
-          \ifnum\value{CREDITS@concepts} > 1
-            \ifnum\value{CREDITSADDED@concepts} > 0
-                \pgfmathresult
-            \fi
-          \fi
+          % If yes, add a comma before the author acronym if >=1 author was already added
+          \pgfmathparse{int(\entry > 0) && \value{CREDITSADDED@concepts} > 0 && \value{CREDITS@concepts} > 1 ? ", " : ""}%
+          \pgfmathresult
           % Add the author acronym if they contributed to the concept
           \pgfmathparse{\entry > 0 ? "\name" : ""}%
           \pgfmathresult
-          \ifnum\entry > 0
-            \addtocounter{CREDITSADDED@concepts}{1}%
-        \fi
+          \ifdim\entry pt > 0pt
+              \addtocounter{CREDITSADDED@concepts}{1}%
+           \fi
         }%
         {}%
       }%

--- a/credits.sty
+++ b/credits.sty
@@ -48,6 +48,7 @@
 }
 
 \DeclareBoolOption{horizontal}
+\DeclareBoolOption{skipempty}
 
 \DeclareStringOption[black]{role}
 \DeclareStringOption[white]{grid}
@@ -122,6 +123,7 @@
 }
 \fi
 
+
 \newcommand{\insertcredits}{%
   \begin{tikzpicture}[scale = 0.5]
     \tikzset{%
@@ -130,14 +132,7 @@
       tile/.style    = /credits/tile,
     }
 
-    \foreach \concept [count = \i] in \concepts {%
-      \ifCREDITS@horizontal%
-        \node[concept] at (\i, 0) {\concept};
-      \else%
-        \node[concept] at (0, -\i) {\concept};
-      \fi%
-    }
-
+    % First draw the author names
     \foreach \name/\column [count=\n] in \credits {%
       % Put an author label here. If you want to *rotate* names in
       % a different way because you are using abbreviations, it is
@@ -147,21 +142,53 @@
       \else
         \node[author] at (\n, 0) {\name};
       \fi
-      %
-      \foreach \entry [count = \m] in \column {%
-        \pgfmathparse{\entry*100}
-        \colorlet{fill}{\CREDITS@role!\pgfmathresult}
-        \colorlet{grid}{\CREDITS@grid}
+    }
 
-        \ifCREDITS@horizontal
-          \node[fill = fill, draw = grid, tile] (tile) at (\m, -\n) {};
-        \else%
-          \node[fill = fill, draw = grid, tile] (tile) at (\n, -\m) {};
-        \fi
+    % Next, count the number of contributors per concept
+    \newcounter{row}
+    \foreach \concept [count = \i] in \concepts {%
+      \setcounter{CREDITS@concepts}{0}%
+      \foreach \name/\column in \credits {%
+        \foreach \entry [count=\m] in \column {%
+          \ifthenelse{\i = \m}{%
+            \pgfmathparse{\entry > 0 ? 1 : 0}%
+            \ifthenelse{\pgfmathresult > 0}{%
+              \addtocounter{CREDITS@concepts}{1}%
+            }{}%
+          }%
+          {}%
+        }%
       }%
+     % Add concept if >0 contributors or if we don't skip empty concepts
+     \pgfmathparse{\value{CREDITS@concepts}>0 || \ifCREDITS@skipempty 0\else 1\fi}
+     \ifnum\pgfmathresult=1\relax
+        \addtocounter{row}{1}
+        \ifCREDITS@horizontal%
+          \node[concept] at (\value{row}, 0) {\concept};
+        \else%
+          \node[concept] at (0, -\value{row}) {\concept};
+        \fi%
+      \fi
+        \foreach \name/\column [count=\n] in \credits {%
+          \foreach \entry [count = \m] in \column {%
+            \pgfmathparse{\entry*100}
+            \colorlet{fill}{\CREDITS@role!\pgfmathresult}
+            \colorlet{grid}{\CREDITS@grid}
+            \pgfmathparse{\value{CREDITS@concepts}>0 || \ifCREDITS@skipempty 0\else 1\fi && \m==\i ? 1 : 0}
+            \ifnum\pgfmathresult=1\relax
+                \ifCREDITS@horizontal
+                  \node[fill = fill, draw = grid, tile] (tile) at (\value{row}, -\n) {};
+                \else%
+                  \node[fill = fill, draw = grid, tile] (tile) at (\n, -\value{row}) {};
+                \fi
+              \fi
+            }
+        }%
     }%
   \end{tikzpicture}
 }
+
+
 
 % Required to ensure that we can count active concepts later on when
 % generating text statements.
@@ -184,6 +211,8 @@
         {}%
       }%
     }%
+    \pgfmathparse{\value{CREDITS@concepts}>0 || \ifCREDITS@skipempty 0\else 1\fi}
+    \ifnum\pgfmathresult=1\relax
     {\bfseries\concept: }%
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
@@ -206,5 +235,6 @@
       \CREDITS@separator{}
     }%
     {}%
+    \fi
   }%
 }

--- a/credits.sty
+++ b/credits.sty
@@ -166,16 +166,17 @@
 % Required to ensure that we can count active concepts later on when
 % generating text statements.
 \newcounter{CREDITS@concepts}
+% Initialize a counter for the number of already-added authors
 \newcounter{CREDITSADDED@concepts}
 
 \newcommand{\insertcreditsstatement}{%
-  \foreach \concept [count = \i] in \concepts {%
+  \foreach \concept [count = \i] in \concepts {% 
     \setcounter{CREDITS@concepts}{0}%
     \setcounter{CREDITSADDED@concepts}{0}%
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
-          \pgfmathparse{int(\entry > 0 ? 1 : 0)}%
+          \pgfmathparse{\entry > 0 ? 1 : 0}%
           \ifthenelse{\pgfmathresult > 0}{%
             \addtocounter{CREDITS@concepts}{1}%
           }{}%
@@ -184,7 +185,6 @@
       }%
     }%
     {\bfseries\concept: }%
-    % Initialize a counter for the number of authors for this concept
     \foreach \name/\column [count=\n] in \credits {%
       \foreach \entry [count=\m] in \column {%
         \ifthenelse{\i = \m}{%
@@ -202,7 +202,6 @@
         {}%
       }%
     }%
-    % Only add a separator if this is not the last concept
     \ifthenelse{\i < 14}{%
       \CREDITS@separator{}
     }%


### PR DESCRIPTION
Closes #5 

Introduces a key `skipempty`. If passed, roles without contributors are not displayed. Applies to both \insertcredit and \insertcreditstatement. There's no support for skipping roles in one but not the other.

Slowly learning latex.... :) 

PS: Sorry for the dirty commit history